### PR TITLE
Make filter_time inclusive on beginning timestamp.

### DIFF
--- a/orca/metadata/pathsmanagers.py
+++ b/orca/metadata/pathsmanagers.py
@@ -180,7 +180,7 @@ class OfflinePathsManager(PathsManager):
         """
         new_paths_manager = copy.deepcopy(self)
         new_paths_manager.utc_times_mapping = OrderedDict((k, v) for k, v in self.utc_times_mapping.items()
-                                                          if start_time < k < end_time)
+                                                          if start_time <= k < end_time)
         return new_paths_manager
 
     def chunks_by_integration(self, chunk_size: int) -> List[List[datetime]]:

--- a/tests/metadata/test_pathsmanagers.py
+++ b/tests/metadata/test_pathsmanagers.py
@@ -19,6 +19,16 @@ def test_time_filter():
     assert pm2.utc_times_mapping[datetime(2019, 10, 28, 23, 4, 44)] == \
            '2019-10-22-02:35:47_0005246685093888.000000.dada'
 
+
+def test_time_filter_inclusive_exclusive():
+    pm = OfflinePathsManager(f'{path.dirname(__file__)}/../resources/utc_times_test.txt', '.')
+    b = datetime(2019, 10, 28, 23, 2, 47)
+    e = datetime(2019, 10, 28, 23, 4, 5)
+    pm2 = pm.time_filter(b, e)
+    assert len(pm2.utc_times_mapping) == 6
+    assert b in pm2.utc_times_mapping
+    assert e not in pm2.utc_times_mapping
+
 def test_with_bad_path():
     with pytest.raises(FileNotFoundError):
         pm = OfflinePathsManager(f'{path.dirname(__file__)}/../resources/utc_times_test.txt',


### PR DESCRIPTION
This was a typo in the code -- the documentation indicated that `filter_time` should be inclusive on beginning and exclusive on end.