### PR TITLE
[DONT MERGE] Normalize spectrum with sum of weights.

### DIFF
--- a/orca/transform/spectrum.py
+++ b/orca/transform/spectrum.py
@@ -53,9 +53,9 @@ def gen_spectrum(ms: str, sourcename: str, data_column: str = 'CORRECTED_DATA', 
     if apply_weights:
         weights = np.load(apply_weights).reshape(Nspw, Nints, Nbls, Nchans, Ncorrs).transpose(1,2,0,3,4).reshape(Nints,Nbls,-1,Ncorrs)
         datacol_ma *= np.multiply(datacol, weights)
-        Nbls_eff = np.sum((~datacol_ma * weights), axis=1)
+        Nbls_eff = np.sum((~datacol_ma.mask * weights), axis=1)
     else:
-        Nbls_eff = np.sum(~datacol_ma, axis=1)
+        Nbls_eff = np.sum(~datacol_ma.mask, axis=1)
 
     # Weighted mean along the bl axis.
     datacol_ma = datacol_ma.sum(axis=1) / Nbls_eff


### PR DESCRIPTION
This is for getting the discussion started. **THIS IS NOT TESTED AT ALL YET**

Instead of doing a mean along the bl axis, when applying weights, we should divide the sum along the bl axis by the sum of weights.

The "natural weight" limit is when all the weights are 1, so dividing by the sum is equivalent to doing the mean.

I did a quick comparison of my weights to the size of visibility. The sum of weights is only 15% of the number of elements in the visibility array, so the difference should be quite big.


TODOs:
- There's a test measurement set in tests/resources, I should be able to get a test set up and make sure that I get the right flux (averaged over channels) as does wsclean.
- I'm a little confused about where the rest of the weights go. Presumably each channel would have a different weight as well. Part of me thinks that by doing `datacol_ma=datacol_ma.sum(axis=1)/np.sum((~datacol_ma.mask * weights), axis=1)`, we appear to correct for that, but I don't think that's quite right, since we don't divide the visibility by their weights. So I think we should either make sure that each channel have the same weights, or quantity how channels are weighted different and then decide whether or not to carry on the weights along with the spectra.