### PR TITLE
Add Pipeline for Flagging, Averaging

### DIFF
--- a/orca/celery.py
+++ b/orca/celery.py
@@ -4,7 +4,6 @@ from orca.configmanager import queue_config
 
 CELERY_APP_NAME = 'orca'
 
-# TODO: what if I import a module that imports orca.transform.*?
 
 app = Celery(CELERY_APP_NAME,
              broker=queue_config.broker_uri,
@@ -14,7 +13,8 @@ app = Celery(CELERY_APP_NAME,
                       'orca.tasks.fortests',
                       'orca.transform.spectrum',
                       'orca.transform.imaging',
-                      'orca.transform.photometry'])
+                      'orca.transform.photometry',
+                      'orca.tasks.pipeline_tasks'])
 
 # Optional configuration, see the application user guide.
 app.conf.update(

--- a/orca/tasks/pipeline_tasks.py
+++ b/orca/tasks/pipeline_tasks.py
@@ -1,22 +1,56 @@
 # orca/tasks/pipeline_tasks.py
 
+import os
 from orca.celery import app
 from orca.transform.flagging import flag_ants as original_flag_ants
-from orca.transform.flagging import flag_with_aoflagger as original_flag_with_aoflagger
+#from orca.transform.flagging import flag_with_aoflagger as original_flag_with_aoflagger
+from orca.transform.flagging import flag_with_aoflagger, save_flag_metadata
 from orca.transform.calibration import applycal_data_col as original_applycal_data_col
 from orca.wrapper.wsclean import wsclean as original_wsclean
 from orca.wrapper.ttcal import peel_with_ttcal 
 from orca.transform.averagems import average_frequency
 from orca.wrapper import change_phase_centre
+from orca.utils.calibrationutils import build_output_paths
 from typing import List
+import shutil
+
+@app.task
+def copy_ms_task(original_ms: str, base_output_dir: str = '/lustre/pipeline/slow-averaged/') -> str:
+    """
+    Copy the MS from its original location to slow-averaged directory.
+    Returns the path to the copied MS.
+    """
+
+    output_dir, ms_base = build_output_paths(original_ms, base_output_dir=base_output_dir)
+    copied_ms = os.path.join(output_dir, ms_base + '.ms')
+    shutil.copytree(original_ms, copied_ms)
+    return copied_ms
+
+@app.task
+def remove_ms_task(ms_tuple: tuple) -> str:
+    # ms_tuple = (original_ms, averaged_ms)
+    import shutil
+    original_ms, averaged_ms = ms_tuple
+    shutil.rmtree(original_ms, ignore_errors=True)
+    # Return the averaged_ms path to keep track of it
+    return averaged_ms
+
 
 @app.task
 def flag_ants_task(ms: str, ants: List[int]) -> str:
     return original_flag_ants(ms, ants)
 
+
 @app.task
-def flag_with_aoflagger_task(ms: str, strategy: str, in_memory: bool, n_threads: int) -> str:
-    return original_flag_with_aoflagger(ms, strategy=strategy, in_memory=in_memory, n_threads=n_threads)
+def flag_with_aoflagger_task(ms: str, strategy: str='/opt/share/aoflagger/strategies/nenufar-lite.lua', in_memory: bool=False, n_threads:int=5) -> str:
+    return flag_with_aoflagger(ms, strategy=strategy, in_memory=in_memory, n_threads=n_threads)
+
+@app.task
+def save_flag_metadata_task(ms: str) -> str:
+    output_dir, ms_base = build_output_paths(ms)
+    # Pass output_dir to the save_flag_metadata function
+    return save_flag_metadata(ms, output_dir=output_dir)
+
 
 @app.task
 def applycal_data_col_task(ms: str, gaintable: str) -> str:
@@ -43,11 +77,13 @@ def peel_with_ttcal_task(ms: str, sources: str) -> str:
 
 @app.task
 def average_frequency_task(ms: str, chanbin: int = 4) -> str:
-    """
-    Celery task to perform frequency averaging on an MS.
-    """
-    output_vis = ms.rstrip('/') + '_averaged.ms'
-    return average_frequency(vis=ms, output_vis=output_vis, chanbin=chanbin)
+    output_dir, ms_base = build_output_paths(ms)
+    output_vis = os.path.join(output_dir, f"{ms_base}_averaged.ms")
+    averaged_ms = average_frequency(vis=ms, output_vis=output_vis, chanbin=chanbin)
+    # Return a tuple: (original_ms, averaged_ms)
+    return (ms, averaged_ms)    
+
+
 
 @app.task
 def change_phase_center_task(ms: str, new_phase_center: str) -> str:

--- a/orca/tasks/pipeline_tasks.py
+++ b/orca/tasks/pipeline_tasks.py
@@ -1,0 +1,36 @@
+# orca/tasks/pipeline_tasks.py
+
+from orca.celery import app
+from orca.transform.flagging import flag_ants as original_flag_ants
+from orca.transform.flagging import flag_with_aoflagger as original_flag_with_aoflagger
+from orca.transform.calibration import applycal_data_col as original_applycal_data_col
+from orca.wrapper.wsclean import wsclean as original_wsclean
+from orca.wrapper.ttcal import peel_with_ttcal 
+
+from typing import List
+
+@app.task
+def flag_ants_task(ms: str, ants: List[int]) -> str:
+    return original_flag_ants(ms, ants)
+
+@app.task
+def flag_with_aoflagger_task(ms: str, strategy: str, in_memory: bool, n_threads: int) -> str:
+    return original_flag_with_aoflagger(ms, strategy=strategy, in_memory=in_memory, n_threads=n_threads)
+
+@app.task
+def applycal_data_col_task(ms: str, gaintable: str) -> str:
+#    return original_applycal_data_col(ms, gaintable)
+    out_ms = ms.rstrip('/') + '_calibrated.ms'
+    return original_applycal_data_col(ms, gaintable, out_ms)
+
+@app.task
+def wsclean_task(ms: str, out_dir: str, filename_prefix: str, extra_args: List[str],
+                 num_threads: int, mem_gb: int) -> None:
+    return original_wsclean([ms], out_dir, filename_prefix, extra_args, num_threads, mem_gb)
+
+@app.task
+def peel_with_ttcal_task(ms: str, sources: str) -> str:
+    """
+    Celery task to use TTCal to peel sources.
+    """
+    return peel_with_ttcal(ms, sources)

--- a/orca/tasks/pipeline_tasks.py
+++ b/orca/tasks/pipeline_tasks.py
@@ -6,7 +6,8 @@ from orca.transform.flagging import flag_with_aoflagger as original_flag_with_ao
 from orca.transform.calibration import applycal_data_col as original_applycal_data_col
 from orca.wrapper.wsclean import wsclean as original_wsclean
 from orca.wrapper.ttcal import peel_with_ttcal 
-
+from orca.transform.averagems import average_frequency
+from orca.wrapper import change_phase_centre
 from typing import List
 
 @app.task
@@ -19,6 +20,9 @@ def flag_with_aoflagger_task(ms: str, strategy: str, in_memory: bool, n_threads:
 
 @app.task
 def applycal_data_col_task(ms: str, gaintable: str) -> str:
+    """
+    Celery task to apply calibration to an MS.
+    """
 #    return original_applycal_data_col(ms, gaintable)
     out_ms = ms.rstrip('/') + '_calibrated.ms'
     return original_applycal_data_col(ms, gaintable, out_ms)
@@ -26,7 +30,9 @@ def applycal_data_col_task(ms: str, gaintable: str) -> str:
 @app.task
 def wsclean_task(ms: str, out_dir: str, filename_prefix: str, extra_args: List[str],
                  num_threads: int, mem_gb: int) -> None:
-    return original_wsclean([ms], out_dir, filename_prefix, extra_args, num_threads, mem_gb)
+    original_wsclean([ms], out_dir, filename_prefix, extra_args, num_threads, mem_gb)
+    return ms
+    #return original_wsclean([ms], out_dir, filename_prefix, extra_args, num_threads, mem_gb)
 
 @app.task
 def peel_with_ttcal_task(ms: str, sources: str) -> str:
@@ -34,3 +40,25 @@ def peel_with_ttcal_task(ms: str, sources: str) -> str:
     Celery task to use TTCal to peel sources.
     """
     return peel_with_ttcal(ms, sources)
+
+@app.task
+def average_frequency_task(ms: str, chanbin: int = 4) -> str:
+    """
+    Celery task to perform frequency averaging on an MS.
+    """
+    output_vis = ms.rstrip('/') + '_averaged.ms'
+    return average_frequency(vis=ms, output_vis=output_vis, chanbin=chanbin)
+
+@app.task
+def change_phase_center_task(ms: str, new_phase_center: str) -> str:
+    """
+    Celery task to change the phase center of a calibrated and averaged MS.
+    """
+    try:
+        # Execute the phase center change
+        updated_ms = change_phase_centre.change_phase_center(ms, new_phase_center)
+        return updated_ms
+    except Exception as e:
+        raise RuntimeError(f"Failed to change phase center for {ms}: {e}")
+
+

--- a/orca/tasks/pipeline_tasks.py
+++ b/orca/tasks/pipeline_tasks.py
@@ -135,4 +135,17 @@ def change_phase_center_task(ms: str, new_phase_center: str) -> str:
     except Exception as e:
         raise RuntimeError(f"Failed to change phase center for {ms}: {e}")
 
-
+@app.task
+def extract_original_ms_task(ms_tuple: tuple) -> str:
+    """
+    Extract the original MS path from the tuple (original_ms, averaged_ms) 
+    returned by `average_frequency_task`.
+    
+    Args:
+        ms_tuple (tuple): A tuple where the first element is the original MS 
+                          and the second is the path to the averaged MS.
+    
+    Returns:
+        str: Path to the original MS.
+    """
+    return ms_tuple[0]

--- a/orca/transform/averagems.py
+++ b/orca/transform/averagems.py
@@ -4,6 +4,9 @@ from casacore import tables
 from typing import List
 from os import path
 import logging
+import time
+import os
+from casatasks import mstransform
 log = logging.getLogger(__name__)
 
 
@@ -38,3 +41,35 @@ def average_ms(ms_list: List[str], ref_ms_index: int, out_ms: str, column: str, 
                         raise e
         out_table.putcol(column, averaged_data)
     return path.abspath(out_ms)
+
+
+def average_frequency(vis: str, output_vis: str, chanbin: int = 4) -> str:
+    """
+    Perform frequency averaging on the given measurement set (MS).
+
+    Parameters:
+        vis (str): Path to the input MS file.
+        output_vis (str): Path to the output averaged MS file.
+        chanbin (int): Number of channels to average.
+
+    Returns:
+        str: Path to the averaged MS file.
+    """
+    log.info(f"[Averaging] Starting frequency averaging for: {vis}")
+    start_time = time.time()
+
+    # Perform frequency averaging
+    mstransform(
+        vis=vis,
+        outputvis=output_vis,
+        chanaverage=True,     # Enable channel averaging
+        chanbin=chanbin,      # Average chanbin input channels into one
+        datacolumn='all'      # Process all available data columns
+    )
+
+    elapsed_time = time.time() - start_time
+    log.info(f"[Averaging] Completed frequency averaging for: {vis}")
+    log.info(f"[Averaging] Averaged MS created at: {output_vis}")
+    log.info(f"[Averaging] Time taken: {elapsed_time:.2f} seconds.")
+
+    return output_vis

--- a/orca/transform/averagems.py
+++ b/orca/transform/averagems.py
@@ -55,8 +55,6 @@ def average_frequency(vis: str, output_vis: str, chanbin: int = 4) -> str:
     Returns:
         str: Path to the averaged MS file.
     """
-    log.info(f"[Averaging] Starting frequency averaging for: {vis}")
-    start_time = time.time()
 
     # Perform frequency averaging
     mstransform(
@@ -67,9 +65,6 @@ def average_frequency(vis: str, output_vis: str, chanbin: int = 4) -> str:
         datacolumn='all'      # Process all available data columns
     )
 
-    elapsed_time = time.time() - start_time
-    log.info(f"[Averaging] Completed frequency averaging for: {vis}")
     log.info(f"[Averaging] Averaged MS created at: {output_vis}")
-    log.info(f"[Averaging] Time taken: {elapsed_time:.2f} seconds.")
 
     return output_vis

--- a/orca/transform/flagging.py
+++ b/orca/transform/flagging.py
@@ -12,6 +12,9 @@ from orca.configmanager import execs, telescope as tele
 from orca.utils.maths import core_outrigger_slices
 from orca.utils import flagutils
 
+import os
+from casatools import table
+
 log = logging.getLogger(__name__)
 
 FLAG_COUNT_FACTOR = 10
@@ -115,3 +118,32 @@ def _calculate_avg_bandpass(autos_corrected, bad_row_mask, n_ants, n_ints, n_cha
     autos_corrected[bad_row_mask] = np.nan
     return bp
 
+def save_flag_metadata(ms: str, output_dir: str = '/lustre/pipeline/slow-averaged/') -> str:
+    """
+    Saves flag metadata in a compact binary format.
+    The output file will have a name derived from the MS name.
+    """
+    base_name = os.path.splitext(os.path.basename(ms))[0]  # e.g., "20241127_220727_73MHz"
+    output_file = os.path.join(output_dir, f"{base_name}_flagmeta.bin")
+
+    tb = table()
+    tb.open(ms)
+    flags = tb.getcol('FLAG')  # (pol, chan, row)
+    tb.close()
+
+    total_points = flags.size
+    flagged_points = np.sum(flags)
+    percentage_flagged = (flagged_points / total_points) * 100.0
+
+    log.info(f"MS: {ms}")
+    log.info(f"Total data points: {total_points}")
+    log.info(f"Flagged points: {flagged_points}")
+    log.info(f"Percentage of flagged data: {percentage_flagged:.2f}%")
+
+    # Pack the flags into a binary format
+    bit_packed = np.packbits(flags.flatten().astype(np.uint8))
+    bit_packed.tofile(output_file)
+
+    log.info(f"Flag metadata saved in packed binary format to '{output_file}'.")
+
+    return ms

--- a/orca/transform/flagging.py
+++ b/orca/transform/flagging.py
@@ -126,19 +126,17 @@ def save_flag_metadata(ms: str, output_dir: str = '/lustre/pipeline/slow-average
     base_name = os.path.splitext(os.path.basename(ms))[0]  # e.g., "20241127_220727_73MHz"
     output_file = os.path.join(output_dir, f"{base_name}_flagmeta.bin")
 
-    tb = table()
-    tb.open(ms)
-    flags = tb.getcol('FLAG')  # (pol, chan, row)
-    tb.close()
+    with tables.table(ms, ack=False, readonly=True) as tb:
+        flags = tb.getcol('FLAG')  # Shape: (pol, chan, row)
+                
+    #total_points = flags.size
+    #flagged_points = np.sum(flags)
+    #percentage_flagged = (flagged_points / total_points) * 100.0
 
-    total_points = flags.size
-    flagged_points = np.sum(flags)
-    percentage_flagged = (flagged_points / total_points) * 100.0
-
-    log.info(f"MS: {ms}")
-    log.info(f"Total data points: {total_points}")
-    log.info(f"Flagged points: {flagged_points}")
-    log.info(f"Percentage of flagged data: {percentage_flagged:.2f}%")
+    #log.info(f"MS: {ms}")
+    #log.info(f"Total data points: {total_points}")
+    #log.info(f"Flagged points: {flagged_points}")
+    #log.info(f"Percentage of flagged data: {percentage_flagged:.2f}%")
 
     # Pack the flags into a binary format
     bit_packed = np.packbits(flags.flatten().astype(np.uint8))

--- a/orca/utils/calibrationutils.py
+++ b/orca/utils/calibrationutils.py
@@ -184,7 +184,7 @@ def _flux80_47(flux_hi, sp, output_freq, ref_freq):
 
 
 
-def parse_filename(filename):
+'''def parse_filename(filename):
     pattern = r'(\d{8})_(\d{6})_.*\.ms'
     #match = re.match(pattern, filename)
     base_fname = os.path.basename(filename)
@@ -194,6 +194,21 @@ def parse_filename(filename):
     date_str, time_str = match.groups()
     iso_time = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:8]}T{time_str[:2]}:{time_str[2:4]}:{time_str[4:6]}"
     return iso_time
+'''
+
+def parse_filename(filename):
+    """
+    Parse a filename of the form YYYYMMDD_HHMMSS_anything.ms and extract the UTC time.
+    """
+    pattern = r'(\d{8})_(\d{6})_([^_]+)\.ms'  # Updated pattern to avoid greediness
+    base_fname = os.path.basename(filename)  # Extracts just the filename
+    match = re.match(pattern, base_fname)
+    if not match:
+        raise ValueError(f"Filename does not match the expected format 'YYYYMMDD_HHMMSS_*.ms'. Got: {base_fname}")
+    date_str, time_str, extra = match.groups()
+    iso_time = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:8]}T{time_str[:2]}:{time_str[2:4]}:{time_str[4:6]}"
+    return iso_time
+
 
 def get_lst_from_filename(filename):
     utc_time_iso = parse_filename(filename)
@@ -234,6 +249,10 @@ def get_relative_path(ms_path):
         return relative_path
     elif '/night-time/' in ms_path:
         parts = ms_path.split('/night-time/', 1)
+        relative_path = parts[1].strip('/')
+        return relative_path
+    elif '/fast/pipeline/' in ms_path:
+        parts = ms_path.split('/fast/pipeline/', 1)
         relative_path = parts[1].strip('/')
         return relative_path
     else:

--- a/orca/utils/calibrationutils.py
+++ b/orca/utils/calibrationutils.py
@@ -221,21 +221,23 @@ def is_within_transit_window(filename, window_minutes=4):
     return in_window_sources
 
 def get_relative_path(ms_path):
-    # Extract the sub-path starting after '/slow/' or '/slow-averaged/'
-    # For example, from '/lustre/pipeline/slow/73MHz/2024-11-29/00/20241129_000005_73MHz.ms'
-    # we get '73MHz/2024-11-29/00/20241129_000005_73MHz.ms'
+    # Extract the sub-path starting after '/slow/', '/slow-averaged/', or '/night-time/'
+    # For example, from '/lustre/pipeline/night-time/73MHz/2023-11-21/03/20231121_000005_73MHz.ms'
+    # we get '73MHz/2023-11-21/03/20231121_000005_73MHz.ms'
     if '/slow-averaged/' in ms_path:
         parts = ms_path.split('/slow-averaged/', 1)
         relative_path = parts[1].strip('/')
         return relative_path
-    # If not found, fallback to '/slow/'
     elif '/slow/' in ms_path:
         parts = ms_path.split('/slow/', 1)
         relative_path = parts[1].strip('/')
         return relative_path
+    elif '/night-time/' in ms_path:
+        parts = ms_path.split('/night-time/', 1)
+        relative_path = parts[1].strip('/')
+        return relative_path
     else:
-        raise ValueError("Input MS path does not contain '/slow/' or '/slow-averaged/'")
-
+        raise ValueError("Input MS path does not contain '/slow/', '/slow-averaged/', or '/night-time/'")
 
 def build_output_paths(ms_path, base_output_dir='/lustre/pipeline/slow-averaged/'):
     relative_path = get_relative_path(ms_path)

--- a/orca/utils/flagutils.py
+++ b/orca/utils/flagutils.py
@@ -1,5 +1,9 @@
 import datetime
 import pandas as pd
+import numpy as np
+import os
+import matplotlib.pyplot as plt
+
 
 FLAG_TABLE = '/opt/devel/yuping/ant_flags.csv'
 df = pd.read_csv(FLAG_TABLE, parse_dates=['date'])
@@ -25,3 +29,85 @@ def get_bad_ants(date: datetime.date, sources=['AI-VAR', 'AI-LO']):
     if not res or len(res) == 0:
         raise ValueError(f"No bad antennas found for {date}.")
     return res
+
+def unpack_flag_metadata(input_file: str, original_shape: tuple) -> np.ndarray:
+    """
+    Unpacks binary flag metadata from a packed binary file into its original FLAG column shape.
+
+    Parameters:
+    -----------
+    input_file : str
+        Path to the binary file containing the packed flag data.
+    original_shape : tuple
+        The shape of the original FLAG array (e.g., (polarizations, channels, rows)).
+
+    Returns:
+    --------
+    np.ndarray
+        A Boolean array of the same shape as the original FLAG column.
+    """
+    if not os.path.isfile(input_file):
+        raise FileNotFoundError(f"The file '{input_file}' does not exist.")
+
+    print(f"Loading packed flags from '{input_file}'...")
+    bit_packed = np.fromfile(input_file, dtype=np.uint8)
+
+    # Calculate the total number of bits that need to be unpacked
+    total_bits = np.prod(original_shape)
+    total_bytes = (total_bits + 7) // 8  # Calculate how many bytes are needed
+
+    if bit_packed.size < total_bytes:
+        raise ValueError(f"Insufficient data in the file. Expected at least {total_bytes} bytes, got {bit_packed.size}.")
+
+    print("Unpacking flags...")
+    flags = np.unpackbits(bit_packed)[:total_bits].astype(bool)  # Only unpack the required number of bits
+    flags = flags.reshape(original_shape)
+
+    print(f"Unpacked FLAG column shape: {flags.shape}")
+    print(f"Total flagged points: {np.sum(flags)}")
+
+    return flags
+
+def plot_flag_metadata_all_polarizations_subplot(flags: np.ndarray, output_dir: str = None) -> None:
+    """
+    Plots the flag metadata for all polarizations in a single subplot figure.
+
+    Parameters:
+    -----------
+    flags : np.ndarray
+        A Boolean array of shape (polarizations, channels, rows) representing the flag data.
+    output_dir : str, optional
+        Directory where the plot will be saved. If None, the plot is displayed interactively.
+    """
+    if flags.ndim != 3:
+        raise ValueError(f"Expected a 3D FLAG array (polarizations, channels, rows), but got shape {flags.shape}.")
+
+    num_polarizations = flags.shape[0]
+
+    fig, axes = plt.subplots(1, num_polarizations, figsize=(20, 4)) 
+
+    for pol in range(num_polarizations):
+        ax = axes[pol] if num_polarizations > 1 else axes
+        im = ax.imshow(flags[pol], aspect='auto', cmap='viridis', origin='lower')
+        ax.set_title(f'Polarization {pol}')
+        ax.set_xlabel('Row Index')
+        if pol == 0:
+            ax.set_ylabel('Channel Index')
+
+    fig.colorbar(im, ax=axes.ravel().tolist(), label='Flagged (True/False)')
+
+    if output_dir:
+        output_path = os.path.join(output_dir, 'flag_metadata_all_polarizations.png')
+        plt.savefig(output_path)
+        print(f"Saved subplot for all polarizations to '{output_path}'")
+    else:
+        plt.show()
+
+    plt.close()
+
+
+# Test the function on the provided file
+# unpacked_flags = unpack_flag_metadata(input_file, original_shape)
+# plot_flag_metadata_all_polarizations_subplot(unpacked_flags, output_dir=None)  # Set output_dir to save the plot instead of displaying it
+
+

--- a/orca/wrapper/ttcal.py
+++ b/orca/wrapper/ttcal.py
@@ -4,32 +4,29 @@ import subprocess
 import logging
 import os
 
-log = logging.getLogger(__name__)
-
-TTCAL_EXEC = '/opt/astro/mwe/bin/ttcal-0.3.0'
-
+TTCAL_EXEC = '/opt/devel/pipeline/envs/julia060/bin/ttcal.jl'
 
 def peel_with_ttcal(ms: str, sources: str):
-    """Use TTCal to peel sources.
-
-    Args:
-        ms: Path to the measurement set.
-        sources: Path to the sources.json file.
-
-    Returns: The path to the measurement set because TTCal reads from and writes to it.
-
-    """
+    """Use TTCal to peel sources."""
     new_env = dict(os.environ, LD_LIBRARY_PATH='/opt/astro/mwe/usr/lib64:/opt/astro/lib/',
                    AIPSPATH='/opt/astro/casa-data dummy dummy')
-    proc = subprocess.Popen([TTCAL_EXEC, 'peel', ms, sources, '--beam', 'sine', '--maxiter', '50',
-                             '--tolerance', '1e-4', '--minuvw', '10'], env=new_env,
-                            stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+
+    julia_path = '/opt/devel/pipeline/envs/julia060/bin/julia'
+
+    proc = subprocess.Popen(
+        [julia_path, TTCAL_EXEC, 'peel', ms, sources, '--beam', 'sine', '--maxiter', '50',
+         '--tolerance', '1e-4', '--minuvw', '10'],
+        env=new_env,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE
+    )
     try:
         stdoutdata, stderrdata = proc.communicate()
-        if proc.returncode is not 0:
+        if proc.returncode != 0:
             logging.error(f'Error in TTCal: {stderrdata.decode()}')
             logging.info(f'stdout is {stdoutdata.decode()}')
             raise Exception('Error in TTCal.')
     finally:
         proc.terminate()
     return ms
+

--- a/orca/wrapper/ttcal.py
+++ b/orca/wrapper/ttcal.py
@@ -7,7 +7,14 @@ import os
 TTCAL_EXEC = '/opt/devel/pipeline/envs/julia060/bin/ttcal.jl'
 
 def peel_with_ttcal(ms: str, sources: str):
-    """Use TTCal to peel sources."""
+    """Use TTCal to peel sources.
+    
+    Args:
+        ms: Path to the measurement set.
+        sources: Path to the sources.json file.
+    
+    Returns: The path to the measurement set because TTCal reads from and writes to it.
+    """
     new_env = dict(os.environ, LD_LIBRARY_PATH='/opt/astro/mwe/usr/lib64:/opt/astro/lib/',
                    AIPSPATH='/opt/astro/casa-data dummy dummy')
 

--- a/pipeline/flagging_averaging.py
+++ b/pipeline/flagging_averaging.py
@@ -59,31 +59,32 @@ for vis in ms_files:
 
     all_chains.append(pipeline_chain)
 
-if all_chains:
-    print("Submitting tasks for all MS files...")
-    group_result = group(all_chains)()
+if __name__ == "__main__":
+    if all_chains:
+        print("Submitting tasks for all MS files...")
+        group_result = group(all_chains)()
 
-    # Wait for all tasks to complete
-    print("Waiting for tasks to finish...")
-    try:
-        group_result.join()
-        print("All tasks have been processed successfully!")
-    except Exception as e:
-        logging.error(f"Error processing tasks: {e}")
-        print(f"Error processing tasks: {e}")
+        # Wait for all tasks to complete
+        print("Waiting for tasks to finish...")
+        try:
+            group_result.join()
+            print("All tasks have been processed successfully!")
+        except Exception as e:
+            logging.error(f"Error processing tasks: {e}")
+            print(f"Error processing tasks: {e}")
 
-        # Check individual task results
-        for result in group_result.results:
-            if not result.successful():
-                try:
-                    exc = result.result
-                    task_name = result.task_id
-                    logging.error(f"Task {task_name} failed with error: {exc}")
-                    print(f"Task {task_name} failed with error: {exc}")
-                except Exception as sub_e:
-                    logging.error(f"Unable to retrieve task result: {sub_e}")
-                    print(f"Unable to retrieve task result: {sub_e}")
+            # Check individual task results
+            for result in group_result.results:
+                if not result.successful():
+                    try:
+                        exc = result.result
+                        task_name = result.task_id
+                        logging.error(f"Task {task_name} failed with error: {exc}")
+                        print(f"Task {task_name} failed with error: {exc}")
+                    except Exception as sub_e:
+                        logging.error(f"Unable to retrieve task result: {sub_e}")
+                        print(f"Unable to retrieve task result: {sub_e}")
 
-else:
-    print("No tasks to process.")
+    else:
+        print("No tasks to process.")
 

--- a/pipeline/flagging_averaging.py
+++ b/pipeline/flagging_averaging.py
@@ -1,0 +1,41 @@
+from celery import chain
+from orca.tasks.pipeline_tasks import (
+    copy_ms_task,
+    flag_with_aoflagger_task,
+    save_flag_metadata_task,
+    average_frequency_task,
+    remove_ms_task
+)
+import glob
+import os
+from orca.utils.calibrationutils import is_within_transit_window
+import shutil
+
+
+# Directory with MS files
+directory = "/lustre/pipeline/slow/73MHz/2024-11-29/00/"
+ms_files = sorted(glob.glob(f"{directory}*.ms"))
+
+
+# Parameters
+strategy = '/opt/share/aoflagger/strategies/nenufar-lite.lua'
+in_memory = False
+n_threads = 5
+
+for vis in ms_files:
+    sources_in_window = is_within_transit_window(vis, window_minutes=4)
+
+    # Create the pipeline: first copy, then process
+    pipeline_chain = chain(
+        copy_ms_task.s(vis),                            # Copies the MS asynchronously
+        flag_with_aoflagger_task.s(),                   # Flags the newly copied MS
+        save_flag_metadata_task.s(),                    # Saves flag metadata
+        average_frequency_task.s(chanbin=4)             # Averages frequency
+    )
+
+    # If not in transit, remove the MS after processing
+    if not sources_in_window:
+        pipeline_chain = pipeline_chain | remove_ms_task.s()
+
+    # Run the pipeline
+    pipeline_chain.apply_async()

--- a/pipeline/flagging_averaging.py
+++ b/pipeline/flagging_averaging.py
@@ -1,41 +1,89 @@
-from celery import chain
+from celery import chain, group
 from orca.tasks.pipeline_tasks import (
-    copy_ms_task,
     flag_with_aoflagger_task,
     save_flag_metadata_task,
     average_frequency_task,
-    remove_ms_task
+    copy_ms_task,
+    remove_ms_task,
+    extract_original_ms_task
 )
 import glob
 import os
+import time
+import logging
 from orca.utils.calibrationutils import is_within_transit_window
-import shutil
+
+# Setup logging
+logging.basicConfig(filename='pipeline_errors.log', level=logging.ERROR, 
+                    format='%(asctime)s - %(levelname)s - %(message)s')
 
 
-# Directory with MS files
-directory = "/lustre/pipeline/slow/73MHz/2024-11-29/00/"
-ms_files = sorted(glob.glob(f"{directory}*.ms"))
+root_directory = "/lustre/pipeline/slow/"
+freq_dir = "73MHz"  
+date_subdir = "2024-12-05/00"  
 
+directory = os.path.join(root_directory, freq_dir, date_subdir)
+ms_files = sorted(glob.glob(f"{directory}/*.ms"))
 
-# Parameters
-strategy = '/opt/share/aoflagger/strategies/nenufar-lite.lua'
-in_memory = False
-n_threads = 5
+all_chains = []
 
 for vis in ms_files:
     sources_in_window = is_within_transit_window(vis, window_minutes=4)
 
-    # Create the pipeline: first copy, then process
-    pipeline_chain = chain(
-        copy_ms_task.s(vis),                            # Copies the MS asynchronously
-        flag_with_aoflagger_task.s(),                   # Flags the newly copied MS
-        save_flag_metadata_task.s(),                    # Saves flag metadata
-        average_frequency_task.s(chanbin=4)             # Averages frequency
+    # Pipeline steps:
+    # 1. Flag original MS in place
+    # 2. Save flag metadata to slow-averaged/
+    # 3. Frequency average to slow-averaged/
+    # 4. If calibrator present: copy original MS to slow-averaged/
+    #    If not: remove original MS.
+
+    base_chain = chain(
+        # Run AOFlagger on the original MS in slow/
+        flag_with_aoflagger_task.s(vis),
+
+        # Save flag metadata to slow-averaged/
+        save_flag_metadata_task.s(),
+
+        # Average frequency and put averaged MS in slow-averaged/
+        average_frequency_task.s(chanbin=4)
     )
 
-    # If not in transit, remove the MS after processing
-    if not sources_in_window:
-        pipeline_chain = pipeline_chain | remove_ms_task.s()
+    if sources_in_window:
+        # Calibrator present:
+        # After averaging, copy the original MS to slow-averaged
+        # We need to extract the original ms from the (ms, averaged_ms) tuple first.
+        pipeline_chain = base_chain | extract_original_ms_task.s() | copy_ms_task.s()
+    else:
+        # No calibrator:
+        pipeline_chain = base_chain 
 
-    # Run the pipeline
-    pipeline_chain.apply_async()
+    all_chains.append(pipeline_chain)
+
+if all_chains:
+    print("Submitting tasks for all MS files...")
+    group_result = group(all_chains)()
+
+    # Wait for all tasks to complete
+    print("Waiting for tasks to finish...")
+    try:
+        group_result.join()
+        print("All tasks have been processed successfully!")
+    except Exception as e:
+        logging.error(f"Error processing tasks: {e}")
+        print(f"Error processing tasks: {e}")
+
+        # Check individual task results
+        for result in group_result.results:
+            if not result.successful():
+                try:
+                    exc = result.result
+                    task_name = result.task_id
+                    logging.error(f"Task {task_name} failed with error: {exc}")
+                    print(f"Task {task_name} failed with error: {exc}")
+                except Exception as sub_e:
+                    logging.error(f"Unable to retrieve task result: {sub_e}")
+                    print(f"Unable to retrieve task result: {sub_e}")
+
+else:
+    print("No tasks to process.")
+

--- a/pipeline/flagging_averaging_nighttime.py
+++ b/pipeline/flagging_averaging_nighttime.py
@@ -1,0 +1,66 @@
+from celery import chain
+from orca.tasks.pipeline_tasks import (
+    copy_ms_nighttime_task,  
+    flag_with_aoflagger_task,
+    save_flag_metadata_nighttime_task,
+    average_frequency_nighttime_task,
+    remove_ms_task
+)
+import glob
+import os
+from orca.utils.calibrationutils import is_within_transit_window, get_lst_from_filename
+
+def is_within_lst_range(ms: str, start_hour=11, end_hour=14) -> bool:
+    """
+    Check if the LST time of the measurement set is within the specified inclusive range.
+    """
+    lst = get_lst_from_filename(ms).hour
+    return (start_hour <= lst <= end_hour)
+
+
+root_directory = "/lustre/pipeline/night-time/"
+freq_dirs = [
+    "13MHz", "18MHz", "23MHz", "27MHz", "32MHz", "36MHz", 
+    "41MHz", "46MHz", "50MHz", "55MHz", "59MHz", "64MHz", 
+    "69MHz", "73MHz", "78MHz", "82MHz"
+]
+
+
+for freq in freq_dirs:
+    directory = os.path.join(root_directory, freq, "2023-11-21/06")
+    ms_files = sorted(glob.glob(f"{directory}/*.ms")) 
+
+    for vis in ms_files:
+        sources_in_window = is_within_transit_window(vis, window_minutes=4)
+        in_lst_range = is_within_lst_range(vis, 11, 14)
+
+        if sources_in_window or in_lst_range:
+            # i) LST range 11-14 or calibrator
+            # - Copy the MS file 
+            # - Flag the copy
+            # - Save flag metadata
+            # - Frequency average to 96 kHz
+            # - Remove the duplicate 
+            pipeline_chain = chain(
+                copy_ms_nighttime_task.s(vis),  # Duplicate the MS 
+                flag_with_aoflagger_task.s(),  # Flag the copy
+                save_flag_metadata_nighttime_task.s(),  # Save flag metadata
+                average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
+                remove_ms_task.s()  # Remove the copy after processing
+            )
+        else:
+            # ii) All other LST ranges
+            # - Flag the original MS directly
+            # - Save flag metadata
+            # - Frequency average to 96 kHz
+            # - Remove the original
+            pipeline_chain = chain(
+                flag_with_aoflagger_task.s(vis),  # Flag the original MS
+                save_flag_metadata_nighttime_task.s(),  # Save flag metadata
+                average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
+                remove_ms_task.s()  # Remove the original MS after processing
+            )
+
+        # Run the pipeline
+        pipeline_chain.apply_async()
+

--- a/pipeline/flagging_averaging_nighttime.py
+++ b/pipeline/flagging_averaging_nighttime.py
@@ -35,81 +35,83 @@ freq_dirs = [
 
 date_hour_subdirs = [f"2023-12-07/{str(hour).zfill(2)}" for hour in range(1, 15)]
 
-# Loop over each hourly subdirectory
-for idx, date_hour_subdir in enumerate(date_hour_subdirs):
-    print(f"Processing {date_hour_subdir}...")
+if __name__ == "__main__":
+    # Loop over each hourly subdirectory
+    for idx, date_hour_subdir in enumerate(date_hour_subdirs):
+        print(f"Processing {date_hour_subdir}...")
 
-    # List to hold all chains for this hourly batch
-    all_chains = []
+        # List to hold all chains for this hourly batch
+        all_chains = []
 
-    for freq in freq_dirs:
-        directory = os.path.join(root_directory, freq, date_hour_subdir)
-        ms_files = sorted(glob.glob(f"{directory}/*.ms")) 
+        for freq in freq_dirs:
+            directory = os.path.join(root_directory, freq, date_hour_subdir)
+            ms_files = sorted(glob.glob(f"{directory}/*.ms")) 
 
-        for vis in ms_files:
-            sources_in_window = is_within_transit_window(vis, window_minutes=4)
-            in_lst_range = is_within_lst_range(vis, 11, 14)
+            for vis in ms_files:
+                sources_in_window = is_within_transit_window(vis, window_minutes=4)
+                in_lst_range = is_within_lst_range(vis, 11, 14)
 
-            if sources_in_window or in_lst_range:
-                # i) LST range 11-14 or calibrator
-                # - Copy the MS file 
-                # - Flag the copy
-                # - Save flag metadata
-                # - Frequency average to 96 kHz
-                # - Remove the duplicate 
-                pipeline_chain = chain(
-                    copy_ms_nighttime_task.s(vis),  # Duplicate the MS 
-                    flag_with_aoflagger_task.s(),  # Flag the copy
-                    save_flag_metadata_nighttime_task.s(),  # Save flag metadata
-                    average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
-                    remove_ms_task.s()  # Remove the copy after processing
-                )
-            else:
-                # ii) All other LST ranges
-                # - Flag the original MS directly
-                # - Save flag metadata
-                # - Frequency average to 96 kHz
-                # - Remove the original
-                pipeline_chain = chain(
-                    flag_with_aoflagger_task.s(vis),  # Flag the original MS
-                    save_flag_metadata_nighttime_task.s(),  # Save flag metadata
-                    average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
-                    remove_ms_task.s()  # Remove the original MS after processing
-                )
+                if sources_in_window or in_lst_range:
+                    # i) LST range 11-14 or calibrator
+                    # - Copy the MS file 
+                    # - Flag the copy
+                    # - Save flag metadata
+                    # - Frequency average to 96 kHz
+                    # - Remove the duplicate 
+                    pipeline_chain = chain(
+                        copy_ms_nighttime_task.s(vis),  # Duplicate the MS 
+                        flag_with_aoflagger_task.s(),  # Flag the copy
+                        save_flag_metadata_nighttime_task.s(),  # Save flag metadata
+                        average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
+                        remove_ms_task.s()  # Remove the copy after processing
+                    )
+                else:
+                    # ii) All other LST ranges
+                    # - Flag the original MS directly
+                    # - Save flag metadata
+                    # - Frequency average to 96 kHz
+                    # - Remove the original
+                    pipeline_chain = chain(
+                        flag_with_aoflagger_task.s(vis),  # Flag the original MS
+                        save_flag_metadata_nighttime_task.s(),  # Save flag metadata
+                        average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
+                        remove_ms_task.s()  # Remove the original MS after processing
+                    )
 
-            # Add the pipeline chain to the list for this hour
-            all_chains.append(pipeline_chain)
+                # Add the pipeline chain to the list for this hour
+                all_chains.append(pipeline_chain)
 
-    if all_chains:
-        random.shuffle(all_chains)
 
-        # Run all chains as a single group for the current hourly subdirectory
-        print(f"Submitting tasks for {date_hour_subdir} at {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())} UTC...")
-        group_result = group(all_chains)()
+        if all_chains:
+            random.shuffle(all_chains)
 
-        # Wait for all tasks for this hour to complete
-        print(f"Waiting for tasks to finish for {date_hour_subdir}...")
+            # Run all chains as a single group for the current hourly subdirectory
+            print(f"Submitting tasks for {date_hour_subdir} at {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())} UTC...")
+            group_result = group(all_chains)()
 
-        try:
-            group_result.join()  # This will block until all tasks are finished
-            print(f"All tasks for {date_hour_subdir} have been processed successfully!")
-        except Exception as e:
-            logging.error(f"Error processing tasks for {date_hour_subdir}: {e}")
-            print(f"Error processing tasks for {date_hour_subdir}: {e}")
+            # Wait for all tasks for this hour to complete
+            print(f"Waiting for tasks to finish for {date_hour_subdir}...")
 
-            # Check individual results to log which specific tasks failed
-            for result in group_result.results:
-                if not result.successful():
-                    try:
-                        exc = result.result  # The actual exception raised
-                        task_name = result.task_id
-                        logging.error(f"Task {task_name} failed in {date_hour_subdir} with error: {exc}")
-                        print(f"Task {task_name} failed in {date_hour_subdir} with error: {exc}")
-                    except Exception as sub_e:
-                        logging.error(f"Unable to retrieve task result for {date_hour_subdir}: {sub_e}")
-                        print(f"Unable to retrieve task result for {date_hour_subdir}: {sub_e}")
+            try:
+                group_result.join()  # This will block until all tasks are finished
+                print(f"All tasks for {date_hour_subdir} have been processed successfully!")
+            except Exception as e:
+                logging.error(f"Error processing tasks for {date_hour_subdir}: {e}")
+                print(f"Error processing tasks for {date_hour_subdir}: {e}")
 
-    else:
-        print(f"No tasks to process for {date_hour_subdir}. Moving to the next hour.")
+                # Check individual results to log which specific tasks failed
+                for result in group_result.results:
+                    if not result.successful():
+                        try:
+                            exc = result.result  # The actual exception raised
+                            task_name = result.task_id
+                            logging.error(f"Task {task_name} failed in {date_hour_subdir} with error: {exc}")
+                            print(f"Task {task_name} failed in {date_hour_subdir} with error: {exc}")
+                        except Exception as sub_e:
+                            logging.error(f"Unable to retrieve task result for {date_hour_subdir}: {sub_e}")
+                            print(f"Unable to retrieve task result for {date_hour_subdir}: {sub_e}")
 
-    time.sleep(5)  # Small delay before processing the next hour
+        else:
+            print(f"No tasks to process for {date_hour_subdir}. Moving to the next hour.")
+
+        time.sleep(5)  # Small delay before processing the next hour

--- a/pipeline/flagging_averaging_nighttime.py
+++ b/pipeline/flagging_averaging_nighttime.py
@@ -1,4 +1,4 @@
-from celery import chain
+from celery import chain, group
 from orca.tasks.pipeline_tasks import (
     copy_ms_nighttime_task,  
     flag_with_aoflagger_task,
@@ -8,7 +8,15 @@ from orca.tasks.pipeline_tasks import (
 )
 import glob
 import os
+import time
+import logging
 from orca.utils.calibrationutils import is_within_transit_window, get_lst_from_filename
+import random
+
+
+# Setup logging
+logging.basicConfig(filename='pipeline_errors.log', level=logging.ERROR, 
+                    format='%(asctime)s - %(levelname)s - %(message)s')
 
 def is_within_lst_range(ms: str, start_hour=11, end_hour=14) -> bool:
     """
@@ -25,42 +33,83 @@ freq_dirs = [
     "69MHz", "73MHz", "78MHz", "82MHz"
 ]
 
+date_hour_subdirs = [f"2023-12-07/{str(hour).zfill(2)}" for hour in range(1, 15)]
 
-for freq in freq_dirs:
-    directory = os.path.join(root_directory, freq, "2023-11-21/06")
-    ms_files = sorted(glob.glob(f"{directory}/*.ms")) 
+# Loop over each hourly subdirectory
+for idx, date_hour_subdir in enumerate(date_hour_subdirs):
+    print(f"Processing {date_hour_subdir}...")
 
-    for vis in ms_files:
-        sources_in_window = is_within_transit_window(vis, window_minutes=4)
-        in_lst_range = is_within_lst_range(vis, 11, 14)
+    # List to hold all chains for this hourly batch
+    all_chains = []
 
-        if sources_in_window or in_lst_range:
-            # i) LST range 11-14 or calibrator
-            # - Copy the MS file 
-            # - Flag the copy
-            # - Save flag metadata
-            # - Frequency average to 96 kHz
-            # - Remove the duplicate 
-            pipeline_chain = chain(
-                copy_ms_nighttime_task.s(vis),  # Duplicate the MS 
-                flag_with_aoflagger_task.s(),  # Flag the copy
-                save_flag_metadata_nighttime_task.s(),  # Save flag metadata
-                average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
-                remove_ms_task.s()  # Remove the copy after processing
-            )
-        else:
-            # ii) All other LST ranges
-            # - Flag the original MS directly
-            # - Save flag metadata
-            # - Frequency average to 96 kHz
-            # - Remove the original
-            pipeline_chain = chain(
-                flag_with_aoflagger_task.s(vis),  # Flag the original MS
-                save_flag_metadata_nighttime_task.s(),  # Save flag metadata
-                average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
-                remove_ms_task.s()  # Remove the original MS after processing
-            )
+    for freq in freq_dirs:
+        directory = os.path.join(root_directory, freq, date_hour_subdir)
+        ms_files = sorted(glob.glob(f"{directory}/*.ms")) 
 
-        # Run the pipeline
-        pipeline_chain.apply_async()
+        for vis in ms_files:
+            sources_in_window = is_within_transit_window(vis, window_minutes=4)
+            in_lst_range = is_within_lst_range(vis, 11, 14)
 
+            if sources_in_window or in_lst_range:
+                # i) LST range 11-14 or calibrator
+                # - Copy the MS file 
+                # - Flag the copy
+                # - Save flag metadata
+                # - Frequency average to 96 kHz
+                # - Remove the duplicate 
+                pipeline_chain = chain(
+                    copy_ms_nighttime_task.s(vis),  # Duplicate the MS 
+                    flag_with_aoflagger_task.s(),  # Flag the copy
+                    save_flag_metadata_nighttime_task.s(),  # Save flag metadata
+                    average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
+                    remove_ms_task.s()  # Remove the copy after processing
+                )
+            else:
+                # ii) All other LST ranges
+                # - Flag the original MS directly
+                # - Save flag metadata
+                # - Frequency average to 96 kHz
+                # - Remove the original
+                pipeline_chain = chain(
+                    flag_with_aoflagger_task.s(vis),  # Flag the original MS
+                    save_flag_metadata_nighttime_task.s(),  # Save flag metadata
+                    average_frequency_nighttime_task.s(chanbin=4),  # Average to 96 kHz (chanbin 4)
+                    remove_ms_task.s()  # Remove the original MS after processing
+                )
+
+            # Add the pipeline chain to the list for this hour
+            all_chains.append(pipeline_chain)
+
+    if all_chains:
+        random.shuffle(all_chains)
+
+        # Run all chains as a single group for the current hourly subdirectory
+        print(f"Submitting tasks for {date_hour_subdir} at {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())} UTC...")
+        group_result = group(all_chains)()
+
+        # Wait for all tasks for this hour to complete
+        print(f"Waiting for tasks to finish for {date_hour_subdir}...")
+
+        try:
+            group_result.join()  # This will block until all tasks are finished
+            print(f"All tasks for {date_hour_subdir} have been processed successfully!")
+        except Exception as e:
+            logging.error(f"Error processing tasks for {date_hour_subdir}: {e}")
+            print(f"Error processing tasks for {date_hour_subdir}: {e}")
+
+            # Check individual results to log which specific tasks failed
+            for result in group_result.results:
+                if not result.successful():
+                    try:
+                        exc = result.result  # The actual exception raised
+                        task_name = result.task_id
+                        logging.error(f"Task {task_name} failed in {date_hour_subdir} with error: {exc}")
+                        print(f"Task {task_name} failed in {date_hour_subdir} with error: {exc}")
+                    except Exception as sub_e:
+                        logging.error(f"Unable to retrieve task result for {date_hour_subdir}: {sub_e}")
+                        print(f"Unable to retrieve task result for {date_hour_subdir}: {sub_e}")
+
+    else:
+        print(f"No tasks to process for {date_hour_subdir}. Moving to the next hour.")
+
+    time.sleep(5)  # Small delay before processing the next hour

--- a/pipeline/realtime.py
+++ b/pipeline/realtime.py
@@ -1,0 +1,52 @@
+from celery import chain
+from orca.tasks.pipeline_tasks import (
+    flag_ants_task,
+    flag_with_aoflagger_task,
+    applycal_data_col_task,
+    wsclean_task,
+    peel_with_ttcal_task 
+)
+
+
+import glob
+
+# Specify the directory with ms files
+directory = "/lustre/nkosogor/distributed_pipeline_test_data/5hour_data/"
+
+# Collect all files with the .ms extension
+ms_files = sorted(glob.glob(f"{directory}*.ms"))
+
+# Define constants and parameters
+bad_antennas = '51,79,80,117,137,193,150,178,201,208,224,183,261,211,215, 230,236,239,242,246,294,301,307,289,33,3,41,42,44,92,12,14,17,21,154,56,57,28,127,126'
+bad_antennas_list = [int(ant.strip()) for ant in bad_antennas.split(',')]
+bcal_file = '/lustre/nkosogor/distributed_pipeline_test_data/5hour_data/73.bandpass'
+strategy = '/opt/share/aoflagger/strategies/nenufar-lite.lua'
+in_memory = False
+n_threads = 5
+out_dir = '/lustre/nkosogor/distributed_pipeline_test_data/5hour_data/'
+extra_args = [
+    '-multiscale',
+    '-multiscale-scale-bias', '0.8',
+    '-pol', 'I',
+    '-size', '4096', '4096',
+    '-scale', '0.03125',
+    '-niter', '0',
+    '-casa-mask', '/home/pipeline/cleanmask.mask/',
+    '-mgain', '0.85',
+    '-weight', 'briggs', '0'
+]
+num_threads = 1
+mem_gb = 50
+
+for vis in ms_files:
+    filename_prefix = generate_filename_prefix(vis)
+
+    pipeline_chain = chain(
+        flag_ants_task.s(vis, bad_antennas_list),
+        flag_with_aoflagger_task.s(strategy=strategy, in_memory=in_memory, n_threads=n_threads),
+        applycal_data_col_task.s(gaintable=bcal_file),
+        peel_with_ttcal_task.s(sources='/home/pipeline/sources.json'),  # Add peeling step
+        wsclean_task.s(out_dir=out_dir, filename_prefix=filename_prefix, extra_args=extra_args,
+                       num_threads=num_threads, mem_gb=mem_gb)
+    )
+    pipeline_chain.apply_async()

--- a/pipeline/realtime.py
+++ b/pipeline/realtime.py
@@ -2,28 +2,34 @@ from celery import chain
 from orca.tasks.pipeline_tasks import (
     flag_ants_task,
     flag_with_aoflagger_task,
+    average_frequency_task,
     applycal_data_col_task,
     wsclean_task,
-    peel_with_ttcal_task 
+    peel_with_ttcal_task,
+    change_phase_center_task
 )
 
 
 import glob
+import os
 
 # Specify the directory with ms files
-directory = "/lustre/nkosogor/distributed_pipeline_test_data/5hour_data/"
+directory = "/lustre/nkosogor/distributed_pipeline_test_data/5hour_data/average_testing_full/"
 
 # Collect all files with the .ms extension
 ms_files = sorted(glob.glob(f"{directory}*.ms"))
 
+
 # Define constants and parameters
+chanbin = 4
 bad_antennas = '51,79,80,117,137,193,150,178,201,208,224,183,261,211,215, 230,236,239,242,246,294,301,307,289,33,3,41,42,44,92,12,14,17,21,154,56,57,28,127,126'
 bad_antennas_list = [int(ant.strip()) for ant in bad_antennas.split(',')]
 bcal_file = '/lustre/nkosogor/distributed_pipeline_test_data/5hour_data/73.bandpass'
 strategy = '/opt/share/aoflagger/strategies/nenufar-lite.lua'
 in_memory = False
 n_threads = 5
-out_dir = '/lustre/nkosogor/distributed_pipeline_test_data/5hour_data/'
+#out_dir = '/lustre/nkosogor/distributed_pipeline_test_data/5hour_data/'
+out_dir = directory
 extra_args = [
     '-multiscale',
     '-multiscale-scale-bias', '0.8',
@@ -33,10 +39,21 @@ extra_args = [
     '-niter', '0',
     '-casa-mask', '/home/pipeline/cleanmask.mask/',
     '-mgain', '0.85',
-    '-weight', 'briggs', '0'
+    '-weight', 'briggs', '0',
+    '-no-update-model-required'
 ]
 num_threads = 1
 mem_gb = 50
+
+common_phase_center = '13:18:44.6 +37d11m7.2s'
+
+
+def generate_filename_prefix(ms: str) -> str:
+    # Helper function to generate filename prefix
+    base_name = ms.rstrip('/').split('/')[-1]
+    filename_prefix = base_name.replace('.ms', '')
+    return filename_prefix
+
 
 for vis in ms_files:
     filename_prefix = generate_filename_prefix(vis)
@@ -44,9 +61,11 @@ for vis in ms_files:
     pipeline_chain = chain(
         flag_ants_task.s(vis, bad_antennas_list),
         flag_with_aoflagger_task.s(strategy=strategy, in_memory=in_memory, n_threads=n_threads),
-        applycal_data_col_task.s(gaintable=bcal_file),
-        peel_with_ttcal_task.s(sources='/home/pipeline/sources.json'),  # Add peeling step
-        wsclean_task.s(out_dir=out_dir, filename_prefix=filename_prefix, extra_args=extra_args,
-                       num_threads=num_threads, mem_gb=mem_gb)
+        average_frequency_task.s(chanbin=chanbin), # averaging in freq step 
+        applycal_data_col_task.s(gaintable=bcal_file), 
+        peel_with_ttcal_task.s(sources='/home/pipeline/sources.json'),  # peeling step
+                wsclean_task.s(out_dir=out_dir, filename_prefix=filename_prefix, extra_args=extra_args,
+                       num_threads=num_threads, mem_gb=mem_gb),
+        change_phase_center_task.s(new_phase_center=common_phase_center)
     )
     pipeline_chain.apply_async()

--- a/pipeline/realtime.py
+++ b/pipeline/realtime.py
@@ -54,18 +54,18 @@ def generate_filename_prefix(ms: str) -> str:
     filename_prefix = base_name.replace('.ms', '')
     return filename_prefix
 
+if __name__ == "__main__":
+    for vis in ms_files:
+        filename_prefix = generate_filename_prefix(vis)
 
-for vis in ms_files:
-    filename_prefix = generate_filename_prefix(vis)
-
-    pipeline_chain = chain(
-        flag_ants_task.s(vis, bad_antennas_list),
-        flag_with_aoflagger_task.s(strategy=strategy, in_memory=in_memory, n_threads=n_threads),
-        average_frequency_task.s(chanbin=chanbin), # averaging in freq step 
-        applycal_data_col_task.s(gaintable=bcal_file), 
-        peel_with_ttcal_task.s(sources='/home/pipeline/sources.json'),  # peeling step
-                wsclean_task.s(out_dir=out_dir, filename_prefix=filename_prefix, extra_args=extra_args,
-                       num_threads=num_threads, mem_gb=mem_gb),
-        change_phase_center_task.s(new_phase_center=common_phase_center)
-    )
-    pipeline_chain.apply_async()
+        pipeline_chain = chain(
+            flag_ants_task.s(vis, bad_antennas_list),
+            flag_with_aoflagger_task.s(strategy=strategy, in_memory=in_memory, n_threads=n_threads),
+            average_frequency_task.s(chanbin=chanbin), # averaging in freq step 
+            applycal_data_col_task.s(gaintable=bcal_file), 
+            peel_with_ttcal_task.s(sources='/home/pipeline/sources.json'),  # peeling step
+                    wsclean_task.s(out_dir=out_dir, filename_prefix=filename_prefix, extra_args=extra_args,
+                        num_threads=num_threads, mem_gb=mem_gb),
+            change_phase_center_task.s(new_phase_center=common_phase_center)
+        )
+        pipeline_chain.apply_async()


### PR DESCRIPTION
@yupinghuang 
I've added a few pipelines that I currently run on `calim0-4` using all the available resources. The priority now is to free up some storage on Lustre, so could you take a look at this [pipeline](https://github.com/ovro-lwa/distributed-pipeline/blob/nikita_dev/pipeline/flagging_averaging_nighttime.py)? I've included shuffling of submitted tasks, which sped things up by about 1.5x. But it seems that the bottleneck is now I/O speed. No matter how many of the 48 CPUs on each node I use (I tried several concurrency values), it never gets better than ~1 hour to reduce 1 hour of data. I guess there's not much that can be done about that?

Can you also take a look at this [pipeline](https://github.com/ovro-lwa/distributed-pipeline/blob/nikita_dev/pipeline/realtime.py)? I just used it for testing purposes, and it doesn't include many things yet like QAs. Does it look reasonable?

If I'm using most of the cores, would it be better to decrease `n_threads` for AOflagger to something like 1-2?